### PR TITLE
Fix @MainActor isolation crashes in OAuth + signal listeners

### DIFF
--- a/Sources/Core/Plugins/Events.swift
+++ b/Sources/Core/Plugins/Events.swift
@@ -64,7 +64,7 @@ package final class SignalBus {
       subject
       .filter { listenedSignals.contains($0) }
       .sink { signal in
-        Task { await action(signal) }
+        Task { @MainActor in await action(signal) }
       }
 
     cancellables.insert(cancellable)

--- a/Sources/Core/Session/OAuthHandler.swift
+++ b/Sources/Core/Session/OAuthHandler.swift
@@ -5,7 +5,6 @@ import Foundation
 @MainActor
 class OAuthHandler: NSObject {
   private var webAuthSession: ASWebAuthenticationSession?
-  private var completion: ((Result<String, Error>) -> Void)?
 
   func extractScheme(from callbackURL: String?) throws -> String {
     guard let callbackURL = callbackURL,
@@ -24,11 +23,8 @@ class OAuthHandler: NSObject {
   func authenticate(authURL: String, callbackURLScheme: String) async throws
     -> String
   {
-    return try await withCheckedThrowingContinuation { continuation in
-      self.completion = { result in
-        continuation.resume(with: result)
-      }
-
+    return try await withCheckedThrowingContinuation {
+      (continuation: CheckedContinuation<String, Error>) in
       guard let url = URL(string: authURL) else {
         continuation.resume(
           throwing: BetterAuthSwiftError(message: "Invalid auth URL")
@@ -36,41 +32,35 @@ class OAuthHandler: NSObject {
         return
       }
 
-      webAuthSession = .init(
+      let session = ASWebAuthenticationSession(
         url: url,
         callbackURLScheme: callbackURLScheme
-      ) { [weak self] callbackURL, error in
+      ) { @Sendable callbackURL, error in
         if let error = error {
-          self?.completion?(.failure(error))
-        } else if let callbackURL = callbackURL {
-          guard let cookie = self?.extractCookieFromCallback(callbackURL) else {
-            self?.completion?(
-              .failure(
-                BetterAuthSwiftError(
-                  message: "Failed to extract session cookie from callback URL"
-                )
-              )
-            )
-            return
-          }
-          self?.completion?(.success(cookie))
+          continuation.resume(throwing: error)
+        } else if let callbackURL = callbackURL,
+          let cookie = OAuthHandler.extractCookieFromCallback(callbackURL)
+        {
+          continuation.resume(returning: cookie)
         } else {
-          self?.completion?(
-            .failure(BetterAuthSwiftError(message: "No callback URL received"))
+          continuation.resume(
+            throwing: BetterAuthSwiftError(
+              message: "Failed to extract session cookie from callback URL"
+            )
           )
         }
-
-        self?.webAuthSession = nil
-        self?.completion = nil
       }
 
-      webAuthSession?.presentationContextProvider = self
-      webAuthSession?.prefersEphemeralWebBrowserSession = false
-      webAuthSession?.start()
+      session.presentationContextProvider = self
+      session.prefersEphemeralWebBrowserSession = false
+      self.webAuthSession = session
+      session.start()
     }
   }
 
-  private func extractCookieFromCallback(_ callbackURL: URL) -> String? {
+  nonisolated private static func extractCookieFromCallback(_ callbackURL: URL)
+    -> String?
+  {
     guard
       let components = URLComponents(
         url: callbackURL,


### PR DESCRIPTION
On macOS (Swift 6 runtime), two paths trapped with EXC_BREAKPOINT in libdispatch's _dispatch_assert_queue_fail (main-actor isolation check):

- OAuthHandler.authenticate: ASWebAuthenticationSession invokes its completion handler on a background XPC queue, but the completion closure was @MainActor-isolated (it's a literal inside a @MainActor type and captured self), so the runtime's entry isolation check trapped. Fixed by marking the closure @Sendable (so it carries no actor isolation), capturing the continuation directly, and using a nonisolated static cookie extractor. (A DispatchQueue.main.async inside the closure is not enough — the assertion fires at closure entry, before the body runs.)

- SignalBus.listen: the Combine sink spawned Task { ... } on the global executor, but listeners (e.g. SessionStore) mutate @MainActor @Published state. Hop to the main actor with Task { @MainActor in ... }.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved thread safety mechanisms in event handling.
  * Streamlined OAuth authentication flow for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->