### PR TITLE
Make response fields optional that Better Auth omits/nulls

### DIFF
--- a/Sources/Core/Models/Payloads.swift
+++ b/Sources/Core/Models/Payloads.swift
@@ -129,11 +129,11 @@ public struct SignInSocialRequest: Codable, Sendable {
 
 public struct SignInSocialResponse: Codable, Sendable {
   public let redirect: Bool
-  public let token: String
-  public let user: User
+  public let token: String?
+  public let user: User?
   public let url: String?
 
-  public init(redirect: Bool, token: String, user: User, url: String?) {
+  public init(redirect: Bool, token: String? = nil, user: User? = nil, url: String?) {
     self.redirect = redirect
     self.token = token
     self.user = user

--- a/Sources/Core/Models/Session.swift
+++ b/Sources/Core/Models/Session.swift
@@ -14,8 +14,8 @@ public struct SessionData: Codable, Sendable, Loggable {
   public let id: String
   public let userId: String
   public let token: String
-  public let ipAddress: String
-  public let userAgent: String
+  public let ipAddress: String?
+  public let userAgent: String?
   public let expiresAt: Date
   public let createdAt: Date
   public let updatedAt: Date
@@ -24,8 +24,8 @@ public struct SessionData: Codable, Sendable, Loggable {
     id: String,
     userId: String,
     token: String,
-    ipAddress: String,
-    userAgent: String,
+    ipAddress: String? = nil,
+    userAgent: String? = nil,
     expiresAt: Date,
     createdAt: Date,
     updatedAt: Date


### PR DESCRIPTION
Two structs declared fields as required that real Better Auth responses don't always include, causing JSON decode failures (DecodingError .valueNotFound) on otherwise-valid responses:

- SignInSocialResponse.token / .user: absent in the OAuth *redirect* response (`{ redirect: true, url }`). signIn.social therefore failed to decode and threw before the auth sheet could open.
- SessionData.ipAddress / .userAgent: Better Auth returns these as null for many sessions, so getSession() failed to decode and the session never loaded after sign-in.

Making them optional keeps backward compatibility with the populated (non-redirect / fully-attributed) responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated authentication response data model with optional fields.
  * Enhanced session data model with optional fields for improved request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->